### PR TITLE
fix(iris-780): use labeled inputs in 8ch playout profiles

### DIFF
--- a/pebble-h264-mov-hqaudio-8ch.yml
+++ b/pebble-h264-mov-hqaudio-8ch.yml
@@ -1,5 +1,5 @@
 name: pebble-h264-mov-hqaudio-8ch
-description: H.264 High 4:2:2 playout master for Pebble (1080p50, CBR 35 Mbps, MXF, two-pass) with 8 PCM mono tracks (dubbed audio)
+description: H.264 High 4:2:2 playout master for Pebble with 8 PCM mono tracks (4 stereo language pairs from labeled inputs)
 scaling: bicubic
 encodes:
   - type: X264Encode
@@ -30,59 +30,76 @@ encodes:
       cabac: 1
       scenecut: 0
     audioEncodes:
+      # lang0 = original language stereo pair (audio stream 0 of mezz)
       - type: AudioEncode
         codec: pcm_s16le
         sampleRate: 48000
         channelLayout: mono
-        audioMixPreset: monoCh1
+        inputLabel: lang0
+        audioMixPreset: monoLeft
         filters:
           - "apad=pad_dur=0.1"
       - type: AudioEncode
         codec: pcm_s16le
         sampleRate: 48000
         channelLayout: mono
-        audioMixPreset: monoCh2
+        inputLabel: lang0
+        audioMixPreset: monoRight
+        filters:
+          - "apad=pad_dur=0.1"
+      # lang1..lang3 = dub stereo pairs (audio streams 1..3 of mezz). Optional so
+      # sources with fewer than 4 stereo pairs do not fail the job.
+      - type: AudioEncode
+        codec: pcm_s16le
+        sampleRate: 48000
+        channelLayout: mono
+        inputLabel: lang1
+        audioMixPreset: monoLeft
+        optional: true
         filters:
           - "apad=pad_dur=0.1"
       - type: AudioEncode
         codec: pcm_s16le
         sampleRate: 48000
         channelLayout: mono
-        audioMixPreset: monoCh3
+        inputLabel: lang1
+        audioMixPreset: monoRight
+        optional: true
         filters:
           - "apad=pad_dur=0.1"
       - type: AudioEncode
         codec: pcm_s16le
         sampleRate: 48000
         channelLayout: mono
-        audioMixPreset: monoCh4
+        inputLabel: lang2
+        audioMixPreset: monoLeft
+        optional: true
         filters:
           - "apad=pad_dur=0.1"
       - type: AudioEncode
         codec: pcm_s16le
         sampleRate: 48000
         channelLayout: mono
-        audioMixPreset: monoCh5
+        inputLabel: lang2
+        audioMixPreset: monoRight
+        optional: true
         filters:
           - "apad=pad_dur=0.1"
       - type: AudioEncode
         codec: pcm_s16le
         sampleRate: 48000
         channelLayout: mono
-        audioMixPreset: monoCh6
+        inputLabel: lang3
+        audioMixPreset: monoLeft
+        optional: true
         filters:
           - "apad=pad_dur=0.1"
       - type: AudioEncode
         codec: pcm_s16le
         sampleRate: 48000
         channelLayout: mono
-        audioMixPreset: monoCh7
-        filters:
-          - "apad=pad_dur=0.1"
-      - type: AudioEncode
-        codec: pcm_s16le
-        sampleRate: 48000
-        channelLayout: mono
-        audioMixPreset: monoCh8
+        inputLabel: lang3
+        audioMixPreset: monoRight
+        optional: true
         filters:
           - "apad=pad_dur=0.1"

--- a/playout-mxf-hd-8ch.yml
+++ b/playout-mxf-hd-8ch.yml
@@ -1,5 +1,5 @@
 name: playout-mxf-hd-8ch
-description: MXF XDCAM HD for playout with 8 PCM mono tracks (dubbed audio)
+description: MXF XDCAM HD for playout with 8 PCM mono tracks (4 stereo language pairs from labeled inputs)
 encodes:
   - type: VideoEncode
     codec: mpeg2video
@@ -31,59 +31,76 @@ encodes:
     format: mxf
     twoPass: false
     audioEncodes:
+      # lang0 = original language stereo pair (audio stream 0 of mezz)
       - type: AudioEncode
         codec: pcm_s24le
         samplerate: 48000
         channelLayout: mono
-        audioMixPreset: monoCh1
+        inputLabel: lang0
+        audioMixPreset: monoLeft
         filters:
           - "apad=pad_dur=0.1"
       - type: AudioEncode
         codec: pcm_s24le
         samplerate: 48000
         channelLayout: mono
-        audioMixPreset: monoCh2
+        inputLabel: lang0
+        audioMixPreset: monoRight
+        filters:
+          - "apad=pad_dur=0.1"
+      # lang1..lang3 = dub stereo pairs (audio streams 1..3 of mezz). Optional so
+      # sources with fewer than 4 stereo pairs do not fail the job.
+      - type: AudioEncode
+        codec: pcm_s24le
+        samplerate: 48000
+        channelLayout: mono
+        inputLabel: lang1
+        audioMixPreset: monoLeft
+        optional: true
         filters:
           - "apad=pad_dur=0.1"
       - type: AudioEncode
         codec: pcm_s24le
         samplerate: 48000
         channelLayout: mono
-        audioMixPreset: monoCh3
+        inputLabel: lang1
+        audioMixPreset: monoRight
+        optional: true
         filters:
           - "apad=pad_dur=0.1"
       - type: AudioEncode
         codec: pcm_s24le
         samplerate: 48000
         channelLayout: mono
-        audioMixPreset: monoCh4
+        inputLabel: lang2
+        audioMixPreset: monoLeft
+        optional: true
         filters:
           - "apad=pad_dur=0.1"
       - type: AudioEncode
         codec: pcm_s24le
         samplerate: 48000
         channelLayout: mono
-        audioMixPreset: monoCh5
+        inputLabel: lang2
+        audioMixPreset: monoRight
+        optional: true
         filters:
           - "apad=pad_dur=0.1"
       - type: AudioEncode
         codec: pcm_s24le
         samplerate: 48000
         channelLayout: mono
-        audioMixPreset: monoCh6
+        inputLabel: lang3
+        audioMixPreset: monoLeft
+        optional: true
         filters:
           - "apad=pad_dur=0.1"
       - type: AudioEncode
         codec: pcm_s24le
         samplerate: 48000
         channelLayout: mono
-        audioMixPreset: monoCh7
-        filters:
-          - "apad=pad_dur=0.1"
-      - type: AudioEncode
-        codec: pcm_s24le
-        samplerate: 48000
-        channelLayout: mono
-        audioMixPreset: monoCh8
+        inputLabel: lang3
+        audioMixPreset: monoRight
+        optional: true
         filters:
           - "apad=pad_dur=0.1"


### PR DESCRIPTION
## Why

Follow-up to [encore-profiles#7](https://github.com/TV4/encore-profiles/pull/7). After deploying #7 in dev1 and running a real dubbed playout transcode, only tracks 1–2 had audio — tracks 3–8 were silent. Verified with ffprobe + volumedetect on the test asset \`d8e920cb-9a09-4d67-83a6-2dccab152182\`:

\`\`\`
track 1 | -26.7 dB
track 2 | -26.7 dB
track 3 | -91.0 dB     ← silent
track 4 | -91.0 dB     ← silent
... 5..8 all -91.0 dB
\`\`\`

## Root cause

The mezz output preserves dubs as **4 separate stereo audio streams**, not a single 8-channel layout. The previous design used \`monoCh1..monoCh8\` audioMixPresets (\`FC=c0..FC=c7\`), which only sees channels of stream 0 — channels 2..7 don't exist in that single stream. Tracks 3–8 came out as silence pulled from non-existent channels.

Linear: [IRIS-780](https://linear.app/tv4/issue/IRIS-780/support-8-channel-pcm-output-in-playout-mxf-transcode-for-dubbed-audio)

## What

Switch both 8ch profiles to Encore's **labeled-input** model:

| inputLabel | audioMixPreset | Source stream | Output track |
|---|---|---|---|
| \`lang0\` | \`monoLeft\` | mezz stream 0, ch 0 | track 1 (original L) |
| \`lang0\` | \`monoRight\` | mezz stream 0, ch 1 | track 2 (original R) |
| \`lang1\` | \`monoLeft\` (optional) | mezz stream 1, ch 0 | track 3 (dub 1 L) |
| \`lang1\` | \`monoRight\` (optional) | mezz stream 1, ch 1 | track 4 (dub 1 R) |
| \`lang2\`, \`lang3\` | same pattern (all optional) | streams 2, 3 | tracks 5–8 |

\`monoLeft\` / \`monoRight\` (\`FC=FL\` / \`FC=FR\`) are already deployed in the IrisEncore Spring config — no infrastructure change needed. The \`monoCh1..monoCh8\` presets that #7 originally depended on were never deployed: [tv4-infrastructure#9218](https://github.com/TV4/tv4-infrastructure/pull/9218) is closed.

\`optional: true\` on \`lang1..lang3\` lets Encore skip outputs whose labeled input is missing — sources with fewer than 4 stereo pairs produce 6 / 4 / 2 tracks instead of failing.

The companion Lambda PR ([iris-playout-transcode#3](https://github.com/TV4/iris-playout-transcode/pull/3)) already builds the matching \`inputs[]\` array (1 \`AudioVideo\` for stream 0 + 3 \`Audio\` inputs for streams 1..3).

## Deployment

\`ENCORE_SETTINGS_POLL_DISABLED=true\` — Encore caches profiles at boot, so the next IrisEncore container restart picks these up.

## Test plan

- [ ] After merge + Encore restart, re-run the dev1 dubbed transcode (DR \`d8e920cb-…\`)
- [ ] \`ffprobe\` shows 8 mono streams (existing) — unchanged
- [ ] \`volumedetect\` per track shows real values on tracks 3–8 (new)
- [ ] 4 distinct language pairs by RMS — pairs match within, differ across (new)
- [ ] Non-dubbed sources still hit \`playout-mxf-hd\` / \`pebble-h264-mov-hqaudio\` — no regression