### PR TITLE
feat(pluto): parametrize start timecode to preserve source SOM

### DIFF
--- a/pebble-h264-mov-hqaudio.yml
+++ b/pebble-h264-mov-hqaudio.yml
@@ -20,6 +20,10 @@ encodes:
       colorspace: bt709
       color_trc: bt709
       color_primaries: bt709
+      # Start timecode of the output. The control plane passes the preserved
+      # source SOM via profileParams['timecode'] for PLUTO jobs; defaults to
+      # zero-based when absent (unchanged behaviour).
+      timecode: "#{profileParams['timecode']?:'00:00:00:00'}"
     x264-params:
       nal-hrd: cbr
       force-cfr: 1


### PR DESCRIPTION
Adds a templated timecode param to the PLUTO playout profile (pebble-h264-mov-hqaudio), defaulting to 00:00:00:00 when not provided.

## Why
For PLUTO jobs whose source had a non-zero SOM, the control plane (TV4/iris-control-plane-api#1156) sends the SOM and the requester (TV4/iris-playout-transcode#<branch>) passes it as profileParams['timecode']. This profile must reference that param for it to take effect; ffmpeg then writes it as the MXF start timecode so the output keeps the original SOM.

## Change
```yaml
timecode: "#{profileParams['timecode']?:'00:00:00:00'}"
```

## Scope/safety
Defaults to 00:00:00:00 when no timecode is passed — unchanged, zero-based behaviour for all existing jobs.

Co-Authored-By: Claude Opus 4.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)